### PR TITLE
improvement: update  resolv ~> 0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7.x', '3.0.x', '3.1.x']
+        ruby-version: ['3.1.x', '3.2.x', '3.3.x']
     steps:
       - name: Set up Ruby
         uses: actions/setup-ruby@v1

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ gem 'resolv', '~> 0.4.0'
 group :test do
   gem 'byebug'
   gem 'rake'
-  gem 'rspec', '3.8.0'
-  gem 'rubocop', '0.78.0'
+  gem 'rspec'
+  gem 'rubocop', '1.62.0'
 end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,9 @@
 
 source 'https://rubygems.org'
 
-gem 'caa_rr_patch'
 gem 'openssl'
 gem 'rake'
-gem 'svcb_rr_patch'
+gem 'resolv', '~> 0.4.0'
 
 group :test do
   gem 'byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,13 @@
 
 source 'https://rubygems.org'
 
+gem 'base64'
 gem 'openssl'
-gem 'rake'
 gem 'resolv', '~> 0.4.0'
 
 group :test do
   gem 'byebug'
+  gem 'rake'
   gem 'rspec', '3.8.0'
   gem 'rubocop', '0.78.0'
 end

--- a/exe/nslookupot
+++ b/exe/nslookupot
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-$LOAD_PATH << __dir__ + '/../lib'
+$LOAD_PATH << "#{__dir__}/../lib"
 
 require 'nslookupot'
 

--- a/lib/nslookupot.rb
+++ b/lib/nslookupot.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-require 'resolv'
-require 'caa_rr_patch'
-require 'svcb_rr_patch'
-require 'socket'
 require 'openssl'
 require 'optparse'
+require 'resolv'
+require 'socket'
 
 require 'nslookupot/version'
 require 'nslookupot/error'

--- a/lib/nslookupot.rb
+++ b/lib/nslookupot.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'base64'
 require 'openssl'
 require 'optparse'
 require 'resolv'
@@ -8,4 +9,5 @@ require 'socket'
 require 'nslookupot/version'
 require 'nslookupot/error'
 require 'nslookupot/resolver'
+require 'nslookupot/utils'
 require 'nslookupot/cli'

--- a/lib/nslookupot/cli.rb
+++ b/lib/nslookupot/cli.rb
@@ -102,7 +102,8 @@ module Nslookupot
 
     def s2typeclass(s)
       rr = Resolv::DNS::Resource::IN.const_get(s.upcase)
-      raise NameError unless rr < Resolv::DNS::Resource
+      raise NameError unless rr < Resolv::DNS::Resource ||
+                             rr < Resolv::DNS::Resource::IN::ServiceBinding
 
       rr
     end
@@ -110,7 +111,8 @@ module Nslookupot
     def types
       Resolv::DNS::Resource::IN.constants.filter do |const|
         c = Resolv::DNS::Resource::IN.const_get(const)
-        c < Resolv::DNS::Resource
+        c < Resolv::DNS::Resource ||
+          c < Resolv::DNS::Resource::IN::ServiceBinding
       rescue ArgumentError
         false
       end

--- a/lib/nslookupot/cli.rb
+++ b/lib/nslookupot/cli.rb
@@ -72,7 +72,7 @@ module Nslookupot
       begin
         args = op.parse(argv)
       rescue OptionParser::InvalidOption, OptionParser::MissingArgument => e
-        warn op.to_s
+        warn op
         warn "** #{e.message}"
         exit 1
       end
@@ -90,7 +90,7 @@ module Nslookupot
       end
 
       if args.size != 1
-        warn op.to_s
+        warn op
         warn '** `name` argument is not specified'
         exit 1
       end

--- a/lib/nslookupot/cli.rb
+++ b/lib/nslookupot/cli.rb
@@ -3,6 +3,8 @@
 require 'optparse'
 
 module Nslookupot
+  using Refinements
+
   # rubocop: disable Metrics/ClassLength
   class CLI
     # rubocop: disable Metrics/AbcSize

--- a/lib/nslookupot/utils.rb
+++ b/lib/nslookupot/utils.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Nslookupot
+  PARAMETER_REGISTRY = lambda {
+    registry = %w[
+      mandatory
+      alpn
+      no-default-alpn
+      port
+      ipv4hint
+      ech
+      ipv6hint
+    ]
+    # rubocop:disable Security/Eval
+    (8...65280).each do |nnnn|
+      eval "registry[nnnn] = \"undefine#{nnnn}\"", binding, __FILE__, __LINE__
+    end
+    (65280...65535).each do |nnnn|
+      eval "registry[nnnn] = \"key#{nnnn}\"", binding, __FILE__, __LINE__
+    end
+    # rubocop:enable Security/Eval
+    registry
+  }.call.freeze
+
+  module Refinements
+    refine Resolv::DNS::SvcParams do
+      unless method_defined?(:ocsp_uris)
+        # rubocop: disable Metrics/CyclomaticComplexity
+        define_method(:to_s) do
+          @params.map do |k, v|
+            key = PARAMETER_REGISTRY[k]
+            value = case v
+                    when Resolv::DNS::SvcParam::Mandatory
+                      v.keys.map { |i| PARAMETER_REGISTRY[i] }.join(',')
+                    when Resolv::DNS::SvcParam::ALPN
+                      v.protocol_ids.join(',')
+                    # NOTE: no-default-alpn is not supported
+                    # https://github.com/ruby/resolv/blob/v0.4.0/lib/resolv.rb#L1942
+                    when Resolv::DNS::SvcParam::IPv4Hint
+                      v.addresses.join(',')
+                    when Resolv::DNS::SvcParam::Port
+                      v.port.to_s
+                    when Resolv::DNS::SvcParam::Generic::Key5 # ech
+                      Base64.strict_encode64(v.value)
+                    when Resolv::DNS::SvcParam::IPv6Hint
+                      v.addresses.join(',')
+                    else
+                      v.to_s
+                    end
+            "#{key}=#{value}"
+          end.join(' ')
+        end
+        # rubocop: enable Metrics/CyclomaticComplexity
+      end
+    end
+  end
+end

--- a/lib/nslookupot/utils.rb
+++ b/lib/nslookupot/utils.rb
@@ -26,23 +26,25 @@ module Nslookupot
     refine Resolv::DNS::SvcParams do
       unless method_defined?(:ocsp_uris)
         # rubocop: disable Metrics/CyclomaticComplexity
+        # rubocop: disable Metrics/PerceivedComplexity
         define_method(:to_s) do
           @params.map do |k, v|
             key = PARAMETER_REGISTRY[k]
             value = case v
-                    when Resolv::DNS::SvcParam::Mandatory
+                    in Resolv::DNS::SvcParam::Mandatory
                       v.keys.map { |i| PARAMETER_REGISTRY[i] }.join(',')
-                    when Resolv::DNS::SvcParam::ALPN
+                    in Resolv::DNS::SvcParam::ALPN
                       v.protocol_ids.join(',')
                     # NOTE: no-default-alpn is not supported
                     # https://github.com/ruby/resolv/blob/v0.4.0/lib/resolv.rb#L1942
-                    when Resolv::DNS::SvcParam::IPv4Hint
+                    in Resolv::DNS::SvcParam::IPv4Hint
                       v.addresses.join(',')
-                    when Resolv::DNS::SvcParam::Port
+                    in Resolv::DNS::SvcParam::Port
                       v.port.to_s
-                    when Resolv::DNS::SvcParam::Generic::Key5 # ech
+                    in Resolv::DNS::SvcParam::Generic if v.key_number == 5
+                      # ech
                       Base64.strict_encode64(v.value)
-                    when Resolv::DNS::SvcParam::IPv6Hint
+                    in Resolv::DNS::SvcParam::IPv6Hint
                       v.addresses.join(',')
                     else
                       v.to_s
@@ -51,6 +53,7 @@ module Nslookupot
           end.join(' ')
         end
         # rubocop: enable Metrics/CyclomaticComplexity
+        # rubocop: enable Metrics/PerceivedComplexity
       end
     end
   end

--- a/lib/nslookupot/utils.rb
+++ b/lib/nslookupot/utils.rb
@@ -10,6 +10,7 @@ module Nslookupot
       ipv4hint
       ech
       ipv6hint
+      dohpath
     ]
     # rubocop:disable Security/Eval
     (8...65280).each do |nnnn|
@@ -46,6 +47,8 @@ module Nslookupot
                       Base64.strict_encode64(v.value)
                     in Resolv::DNS::SvcParam::IPv6Hint
                       v.addresses.join(',')
+                    in Resolv::DNS::SvcParam::DoHPath
+                      v.template.encode('utf-8')
                     else
                       v.to_s
                     end

--- a/lib/nslookupot/utils.rb
+++ b/lib/nslookupot/utils.rb
@@ -42,7 +42,9 @@ module Nslookupot
                       v.addresses.join(',')
                     in Resolv::DNS::SvcParam::Port
                       v.port.to_s
-                    in Resolv::DNS::SvcParam::Generic if v.key_number == 5
+                    in Resolv::DNS::SvcParam::Generic \
+                      if Resolv::DNS::SvcParam::Generic.const_get(:Key5) &&
+                         v.is_a?(Resolv::DNS::SvcParam::Generic::Key5)
                       # ech
                       Base64.strict_encode64(v.value)
                     in Resolv::DNS::SvcParam::IPv6Hint

--- a/nslookupot.gemspec
+++ b/nslookupot.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ['nslookupot']
 
   spec.add_development_dependency 'bundler'
+  spec.add_dependency             'base64'
   spec.add_dependency             'openssl'
   spec.add_dependency             'resolv', '~> 0.4.0'
 end

--- a/nslookupot.gemspec
+++ b/nslookupot.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.executables   = ['nslookupot']
 
   spec.add_development_dependency 'bundler'
-  spec.add_dependency             'caa_rr_patch'
   spec.add_dependency             'openssl'
-  spec.add_dependency             'svcb_rr_patch'
+  spec.add_dependency             'resolv', '~> 0.4.0'
 end

--- a/spec/utisl_spec.rb
+++ b/spec/utisl_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+# rubocop: disable Metrics/BlockLength
+RSpec.describe Nslookupot::Refinements do
+  using Nslookupot::Refinements
+
+  context 'SvcParams#to_s' do
+    let(:mandatory) do
+      Resolv::DNS::SvcParams.new(
+        [
+          Resolv::DNS::SvcParam::Mandatory.new([5, 6, 8, 6544])
+        ]
+      )
+    end
+
+    it 'could to_s' do
+      expect(mandatory.to_s).to eq 'mandatory=ech,ipv6hint,undefine8,undefine6544'
+    end
+
+    let(:alpn) do
+      Resolv::DNS::SvcParams.new(
+        [
+          Resolv::DNS::SvcParam::ALPN.new(%w[h2 h3])
+        ]
+      )
+    end
+
+    it 'could to_s' do
+      expect(alpn.to_s).to eq 'alpn=h2,h3'
+    end
+
+    let(:port) do
+      Resolv::DNS::SvcParams.new(
+        [
+          Resolv::DNS::SvcParam::Port.new(80)
+        ]
+      )
+    end
+
+    it 'could to_s' do
+      expect(port.to_s).to eq 'port=80'
+    end
+
+    let(:ipv4hint) do
+      Resolv::DNS::SvcParams.new(
+        [
+          Resolv::DNS::SvcParam::IPv4Hint.new(%w[192.168.0.1])
+        ]
+      )
+    end
+
+    it 'could to_s' do
+      expect(ipv4hint.to_s).to eq 'ipv4hint=192.168.0.1'
+    end
+
+    let(:ipv6hint) do
+      Resolv::DNS::SvcParams.new(
+        [
+          Resolv::DNS::SvcParam::IPv6Hint.new(%w[2001:db8::1])
+        ]
+      )
+    end
+
+    it 'could to_s' do
+      expect(ipv6hint.to_s).to eq 'ipv6hint=2001:db8::1'
+    end
+  end
+end
+# rubocop: enable Metrics/BlockLength

--- a/spec/utisl_spec.rb
+++ b/spec/utisl_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe Nslookupot::Refinements do
     let(:mandatory) do
       Resolv::DNS::SvcParams.new(
         [
-          Resolv::DNS::SvcParam::Mandatory.new([5, 6, 8, 6544])
+          Resolv::DNS::SvcParam::Mandatory.new([5, 6, 8, 65534])
         ]
       )
     end
 
     it 'could to_s' do
-      expect(mandatory.to_s).to eq 'mandatory=ech,ipv6hint,undefine8,undefine6544'
+      expect(mandatory.to_s).to eq 'mandatory=ech,ipv6hint,undefine8,key65534'
     end
 
     let(:alpn) do

--- a/spec/utisl_spec.rb
+++ b/spec/utisl_spec.rb
@@ -66,6 +66,18 @@ RSpec.describe Nslookupot::Refinements do
     it 'could to_s' do
       expect(ipv6hint.to_s).to eq 'ipv6hint=2001:db8::1'
     end
+
+    let(:dohpath) do
+      Resolv::DNS::SvcParams.new(
+        [
+          Resolv::DNS::SvcParam::DoHPath.new('/dns-query{?dns}')
+        ]
+      )
+    end
+
+    it 'could to_s' do
+      expect(dohpath.to_s).to eq 'dohpath=/dns-query{?dns}'
+    end
   end
 end
 # rubocop: enable Metrics/BlockLength


### PR DESCRIPTION
#### 概要
`resolv` の 0.4.0 以上を require するように改修しました。

#### 背景
- `nslookupot` では、これまで `caa_rr_patch`, `svcb_rr_patch` を require することで  caa, svcb, https rr を使えるようにしていた
- `resolv` 0.4.0 は caa, svcb, https rr をサポートするようになった

#### 課題
Ruby 3.3.0 以降はデフォルトで、`resolv` のバージョンが 0.4.0 です。`caa_rr_patch`, `svcb_rr_patch` を require すると、名前が衝突するようになりました。

#### 解決方針
1. `nslookupot` では、`resolv` の 0.4.0 以上を require する
2. `caa_rr_patch`, `svcb_rr_patch` を require しない

ように改修します。